### PR TITLE
Rely on /var/tmp, instead of /tmp, to store temporary data

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 prometheus_jitsi_meet_exporter_checksum_url: https://github.com/systemli/prometheus-jitsi-meet-exporter/releases/download/{{ prometheus_jitsi_meet_exporter_version }}/checksums.txt
 prometheus_jitsi_meet_exporter_download_url: https://github.com/systemli/prometheus-jitsi-meet-exporter/releases/download/{{ prometheus_jitsi_meet_exporter_version }}/prometheus-jitsi-meet-exporter_{{ prometheus_jitsi_meet_exporter_version }}_linux_{{ go_arch_map[ansible_architecture] | d(ansible_architecture) }}.tar.gz
-prometheus_jitsi_meet_exporter_tmp_file: /tmp/prometheus-jitsi-meet-exporter_{{ prometheus_jitsi_meet_exporter_version }}_linux_{{ go_arch_map[ansible_architecture] | d(ansible_architecture) }}.tar.gz
+prometheus_jitsi_meet_exporter_tmp_file: /var/tmp/prometheus-jitsi-meet-exporter_{{ prometheus_jitsi_meet_exporter_version }}_linux_{{ go_arch_map[ansible_architecture] | d(ansible_architecture) }}.tar.gz
 
 go_arch_map:
   i386: '386'


### PR DESCRIPTION
The /var/tmp directory is made available for programs that require temporary files or directories that are preserved between system reboots. Therefore, data stored in /var/tmp is more persistent than data in /tmp.

Files and directories located in /var/tmp must not be deleted when the system is booted. Although data stored in /var/tmp is typically deleted in a site-specific manner, it is recommended that deletions occur at a less frequent interval than /tmp.

This change should prevent noisy diffs which occurred regularly after a machine reboot.